### PR TITLE
Formatted with `cargo clippy` and removed redundant code

### DIFF
--- a/src/hotp.rs
+++ b/src/hotp.rs
@@ -13,20 +13,20 @@ impl Hotp {
             digest: Vec::new(),
         }
     }
-    pub fn with_length<'a>(&'a mut self, n: u32) -> &'a mut Hotp {
+    pub fn with_length(&mut self, n: u32) -> &mut Hotp {
         self.digits = n;
         self
     }
-    pub fn with_digest<'a>(&'a mut self, digest: Vec<u8>) -> &'a mut Hotp {
+    pub fn with_digest(&mut self, digest: Vec<u8>) -> &mut Hotp {
         self.digest = digest;
         self
     }
-    pub fn with_window<'a>(&'a mut self, window: u64) -> &'a mut Hotp {
+    pub fn with_window(&mut self, window: u64) -> &mut Hotp {
         self.window = window;
         self
     }
-    pub fn generate<'a>(
-        &'a self,
+    pub fn generate(
+        &self,
         key: String,
         counter: u128,
     ) -> std::result::Result<String, GenerationError> {
@@ -37,8 +37,8 @@ impl Hotp {
         };
         generate_otp(self.digits, hash)
     }
-    pub fn verify<'a>(
-        &'a self,
+    pub fn verify(
+        &self,
         token: String,
         key: String,
         counter: u128,
@@ -108,7 +108,7 @@ mod tests_verify {
         } else {
             false
         };
-        assert_eq!(true, verified);
+        assert!(verified);
     }
 }
 
@@ -162,7 +162,7 @@ mod test_builder_pattern {
             } else {
                 false
             };
-        assert_eq!(true, result_correct);
-        assert_eq!(false, result_fail);
+        assert!(result_correct);
+        assert!(!result_fail);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ type HmacSha512 = Hmac<Sha512>;
 mod hotp;
 mod totp;
 
-pub use totp::Totp;
 pub use hotp::Hotp;
+pub use totp::Totp;
 
 /// GenerationError enumerates all possible errors returned by this library.
 #[derive(Error, Debug)]
@@ -151,11 +151,7 @@ pub fn get_otp_auth_url() {}
 /// 3.  Same as (2.) but taking the bits from (offset + 2)
 /// 4.  Same as (2.) but taking the bits from (offset + 3)
 /// 5.  OR'ing each of these u32 so that we collapse all of the set bits into one u32
-#[doc(hidden)]
-fn generate_otp(
-    digits: u32,
-    digest_hash: Vec<u8>,
-) -> std::result::Result<String, GenerationError> {
+fn generate_otp(digits: u32, digest_hash: Vec<u8>) -> std::result::Result<String, GenerationError> {
     let offset = if let Some(o) = digest_hash.last() {
         o & 0xf
     } else {
@@ -196,7 +192,6 @@ fn generate_otp(
     }
 }
 
-#[doc(hidden)]
 fn verify_delta(
     token: String,
     counter: u128,
@@ -219,14 +214,12 @@ fn verify_delta(
     Ok(false)
 }
 
-#[doc(hidden)]
 fn generate_secret_default(length: Option<u32>, symbols: Option<bool>) -> String {
     let defined_symbols = if let Some(s) = symbols { s } else { true };
     let defined_length = if let Some(l) = length { l } else { 32 };
     generate_secret_ascii(defined_length, defined_symbols)
 }
 
-#[doc(hidden)]
 fn get_hmac(
     secret: String,
     algorithm: Algorithm,
@@ -238,7 +231,6 @@ fn get_hmac(
     })
 }
 
-#[doc(hidden)]
 fn generate_secret_ascii(length: u32, symbols: bool) -> String {
     let byte_array: Vec<u8> = (0..length).map(|_| rand::random::<u8>()).collect();
 
@@ -258,13 +250,13 @@ fn generate_secret_ascii(length: u32, symbols: bool) -> String {
     secret
 }
 
-#[doc(hidden)]
 fn encode_uri_component(string: String) -> String {
     byte_serialize(string.as_bytes()).collect()
 }
 
-#[doc(hidden)]
-fn generate_otpauth_url() {}
+fn generate_otpauth_url() {
+    todo!()
+}
 
 #[cfg(test)]
 mod digest_tests {

--- a/src/totp.rs
+++ b/src/totp.rs
@@ -47,7 +47,7 @@ impl Totp {
     /// let mut totp_builder = Totp::new();
     /// totp_builder.with_epoch_time_offset(500);
     /// ```
-    pub fn with_epoch_time_offset<'a>(&'a mut self, offset: u64) -> &'a mut Totp {
+    pub fn with_epoch_time_offset(&mut self, offset: u64) -> &mut Totp {
         self.epoch_time_offset = offset;
         self
     }
@@ -68,7 +68,7 @@ impl Totp {
     /// let mut totp_builder = Totp::new();
     /// totp_builder.with_window(5);
     /// ```
-    pub fn with_window<'a>(&'a mut self, window: u64) -> &'a mut Totp {
+    pub fn with_window(&mut self, window: u64) -> &mut Totp {
         self.window = window;
         self
     }
@@ -86,7 +86,7 @@ impl Totp {
     /// let mut totp_builder = Totp::new();
     /// totp_builder.with_digest(vec![1, 2, 3, 4]);
     /// ```
-    pub fn with_digest<'a>(&'a mut self, digest: Vec<u8>) -> &'a mut Totp {
+    pub fn with_digest(&mut self, digest: Vec<u8>) -> &mut Totp {
         self.digest = digest;
         self
     }
@@ -101,7 +101,7 @@ impl Totp {
     /// let mut totp_builder = Totp::new();
     /// let code = totp_builder.generate(key);
     /// ```
-    pub fn generate<'a>(&'a self, key: String) -> std::result::Result<String, GenerationError> {
+    pub fn generate(&self, key: String) -> std::result::Result<String, GenerationError> {
         let counter = self.get_counter() as u128;
         let hash = if self.digest.is_empty() {
             digest(key.clone(), counter, Algorithm::Sha1)?
@@ -121,11 +121,7 @@ impl Totp {
     /// let mut totp_builder = Totp::new();
     /// let verified = totp_builder.verify("1234".to_string(), key);
     /// ```
-    pub fn verify<'a>(
-        &'a self,
-        token: String,
-        key: String,
-    ) -> std::result::Result<bool, GenerationError> {
+    pub fn verify(&self, token: String, key: String) -> std::result::Result<bool, GenerationError> {
         let counter = self.get_counter();
         let windowed_counter = (counter - self.window) as u128;
         let hash = if self.digest.is_empty() {
@@ -133,17 +129,11 @@ impl Totp {
         } else {
             self.digest.clone()
         };
-        verify_delta(
-            token,
-            windowed_counter,
-            6,
-            self.window + self.window,
-            hash,
-        )
+        verify_delta(token, windowed_counter, 6, self.window + self.window, hash)
     }
 
     #[doc(hidden)]
-    fn get_counter<'a>(&'a self) -> u64 {
+    fn get_counter(&self) -> u64 {
         let end = if self.time == 0 {
             SystemTime::now()
         } else {


### PR DESCRIPTION
- `#[doc(hidden)]` is redundant on private items unless you compile docs with `--document-private-items`
- redundant lifetimes in `Hotp` and `Totp` methods.
- `todo!()` in `generate_otpauth_url`
- number operations like `x / 1` or `x & 0xFF` removed in favor of `*x`.
- `assert_eq!(x, true)` replaced with `assert!(x)`, same with `false`.

There are still things that I haven't done that could be done:
- set the edition to `2021`, it should be compatible
- use `debug_assert` to optimize for release builds
- add explanations into assertions (e.g. `assert!(cond, "cond was false, that shouldn't happen")`)
- add support for `otpauth` URL generation (I could make a PR if you wanted)
- put `generate_otpauth_url` behind a feature in the `Cargo.toml` file

Note:
- the secret should be in base32, at least for `otpauth` URLs
- I did not bump the version in `Cargo.toml`